### PR TITLE
Potential fix for code scanning alert no. 2: Stored cross-site scripting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches: [ main ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@types/mdx": "^2.0.13",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "escape-html": "^1.0.3",
         "gray-matter": "^4.0.3",
         "next": "15.2.2",
         "next-mdx-remote": "^5.0.0",
@@ -25,7 +26,8 @@
         "react-to-print": "^3.0.5",
         "rehype-highlight": "^7.0.2",
         "rehype-prism-plus": "^2.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "sanitize-filename": "^1.6.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2632,6 +2634,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -7265,6 +7273,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
@@ -7864,6 +7881,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
@@ -8209,6 +8235,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/escape-html": "^1.0.4",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1250,6 +1251,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@types/mdx": "^2.0.13",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "escape-html": "^1.0.3",
     "gray-matter": "^4.0.3",
     "next": "15.2.2",
     "next-mdx-remote": "^5.0.0",
@@ -29,12 +30,12 @@
     "rehype-highlight": "^7.0.2",
     "rehype-prism-plus": "^2.0.0",
     "remark-gfm": "^4.0.1",
-    "sanitize-filename": "^1.6.3",
-    "escape-html": "^1.0.3"
+    "sanitize-filename": "^1.6.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/escape-html": "^1.0.4",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "react-to-print": "^3.0.5",
     "rehype-highlight": "^7.0.2",
     "rehype-prism-plus": "^2.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "sanitize-filename": "^1.6.3",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import sanitize from 'sanitize-filename';
+import escapeHtml from 'escape-html';
 
 interface Post {
   slug: string;
@@ -24,7 +26,7 @@ function getPosts(): Post[] {
       const { data } = matter(fileContents);
       
       return {
-        slug: fileName.replace(/\.mdx$/, ''),
+        slug: sanitize(fileName.replace(/\.mdx$/, '')),
         frontmatter: data as Post['frontmatter'],
       };
     })
@@ -53,7 +55,7 @@ export default function Home() {
                   {new Date(post.frontmatter.date).toLocaleDateString('he-IL')}
                 </time>
                 <h3 className="text-2xl font-bold mb-3">
-                  <Link href={`/blog/${post.slug}`} className="text-white hover:text-blue-400 transition-colors">
+                  <Link href={`/blog/${escapeHtml(post.slug)}`} className="text-white hover:text-blue-400 transition-colors">
                     {post.frontmatter.title}
                   </Link>
                 </h3>


### PR DESCRIPTION
Potential fix for [https://github.com/EladHeller/blog.eladheller.com/security/code-scanning/2](https://github.com/EladHeller/blog.eladheller.com/security/code-scanning/2)

To fix the stored cross-site scripting vulnerability, we need to sanitize the filenames before using them to create the `slug` property. This can be done by using a library like `sanitize-filename` to ensure that the filenames are safe to use. Additionally, we should escape any potentially harmful characters in the `slug` before using it in the `href` attribute.

1. Install the `sanitize-filename` library.
2. Use the `sanitize-filename` library to sanitize the filenames when creating the `slug` property.
3. Ensure that the `slug` is properly escaped before being used in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
